### PR TITLE
🎨 Enhanced dashboard with picks table & critical tie-game logic

### DIFF
--- a/jobs/update_scores.py
+++ b/jobs/update_scores.py
@@ -225,9 +225,16 @@ class ScoreUpdater:
                     updated_count += 1
 
                 # Update pick survival status
-                if game.winner_abbr is not None:
+                # CRITICAL: For completed games, survival requires WINNING (not tying)
+                if game.home_score is not None and game.away_score is not None:
                     old_survived = pick_result.survived
-                    pick_result.survived = (pick.team_abbr == game.winner_abbr)
+
+                    if game.winner_abbr is not None:
+                        # Normal win/loss - survive only if picked the winner
+                        pick_result.survived = (pick.team_abbr == game.winner_abbr)
+                    else:
+                        # TIE GAME - both teams cause eliminations (nobody survives a tie)
+                        pick_result.survived = False
 
                     if old_survived != pick_result.survived:
                         updated_count += 1
@@ -281,9 +288,15 @@ class ScoreUpdater:
                         PickResult.pick_id == pick.pick_id
                     ).first()
 
-                    if pick_result and game.winner_abbr is not None:
+                    if pick_result:
                         old_survived = pick_result.survived
-                        pick_result.survived = (pick.team_abbr == game.winner_abbr)
+
+                        if game.winner_abbr is not None:
+                            # Normal win/loss - survive only if picked the winner
+                            pick_result.survived = (pick.team_abbr == game.winner_abbr)
+                        else:
+                            # TIE GAME - both teams cause eliminations (nobody survives a tie)
+                            pick_result.survived = False
 
                         if old_survived != pick_result.survived:
                             print(f"  Updated pick for player {pick.player_id}: {old_survived} -> {pick_result.survived}")


### PR DESCRIPTION
## Dashboard Improvements
- Add current week picks breakdown table with team status emojis
- Fix week ordering in stacked bar chart (Week 1,2,3,4 not 1,4,2,3)
- Perfect stacking order (largest teams on bottom)
- Centered annotations over bar segments

## Team Status Emojis
- 💀 Teams that lost, tied, or caused eliminations
- ✅ Teams that won their games
- 🕐 Teams with games not started yet

## Critical Tie Game Logic Fix
- SURVIVOR RULE: Ties count as eliminations (nobody survives a tie)
- Fixed ScoreUpdater to eliminate ALL players who picked teams in tie games
- Handles GB @ DAL 40-40 tie correctly (13 eliminations)

## Sheets Ingestion Reversion Fix
- Replace flawed temp table restoration with real-time ScoreUpdater logic
- Always use current NFL game data for elimination calculations
- Eliminates reversion problem (no more 238→14 elimination resets)
- Consistent logic between sheets and scores cron jobs

🤖 Generated with [Claude Code](https://claude.ai/code)